### PR TITLE
Fix connecting to dual stack (IPv4/IPv6) server

### DIFF
--- a/app/src/main/java/pw/fabi/crewmate/IPHandler.java
+++ b/app/src/main/java/pw/fabi/crewmate/IPHandler.java
@@ -18,9 +18,14 @@ public class IPHandler {
         }  // Policy stuff for android 8+
         try {
             // Among Us only allows IPv4
-            Inet4Address ip = (Inet4Address) Inet4Address.getByName(new URL(url).getHost());
+            InetAddress ips[] = InetAddress.getAllByName(new URL(url).getHost());
 
-            return ip.toString();
+            for (InetAddress ip: ips) {
+                if (ip instanceof Inet4Address) {
+                    return ip.toString();
+                }
+            }
+            Toast.makeText(context,"Found no IPv4 addresses for this hostname",Toast.LENGTH_LONG).show();
         } catch (MalformedURLException e) {
             Toast.makeText(context,"Invalid Address",Toast.LENGTH_LONG).show();
         } catch (UnknownHostException e) {


### PR DESCRIPTION
Among Us does not support IPv6 servers (the server IP address is stored inside
the regionInfo.dat file in binary form in an 4-byte array, a IPv6 address does
not fit). This commit changes the DNS resolution algorithms to only consider
IPv4 addresses and ignore IPv6 addresses.

Closes #3.